### PR TITLE
Add option to ignore users

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ You can set two optional parameters through environment variables:
 - `AMAZON_TLD` is the Amazon TLD for affiliate links (it defaults to "com", but you can set it to "it", "de", "fr" or whatever).
 - `GROUP_REPLACEMENT_MESSAGE` specifies the format for the message that gets posted to groups after deleting the original one. If not set, it will default to `Message by {USER} with Amazon affiliate link:\n\n{MESSAGE}`. In the following table you'll find variables you can use.
 - `RAW_LINKS`: if set to `"true"` disables this bot's "URL beautifier" (which removes all the URL parameters aside from the ASIN and the affiliate tag) and just adds/replaces the tag to the URL. This allows to link to arbitrary pages on Amazon, even non-product ones (e.g. search pages, category pages, etc.)
+- `IGNORE_USERS`: a comma-separated list of usernames (starting with the "@" character) and numeric user IDs whose messages won't be acted upon by the bot, even if they contain matching Amazon links. A valid list would be "@Yourusername,12345678,@IgnoreMeAsWell123". Numeric user IDs are useful for users who do not have Telegram user names defined. You can get yours by contacting [userinfobot](https://t.me/useridinfobot).
 
 | String               | Replacement                                                                                                                |
 | -------------------- | -------------------------------------------------------------------------------------------------------------------------- |

--- a/index.js
+++ b/index.js
@@ -61,6 +61,26 @@ const rawUrlRegex = new RegExp(
   "ig"
 );
 
+var usernames_to_ignore = [];
+var user_ids_to_ignore = [];
+
+if (process.env.IGNORE_USERS) {
+  const usernameRegex = /@([^\s]+)/gi;
+  const userIdRegex = /([0-9]+)/gi;
+  let to_ignore = process.env.IGNORE_USERS.split(",");
+  to_ignore.forEach((ignore) => {
+    let usernameResult = usernameRegex.exec(ignore.trim());
+    if (usernameResult) {
+      usernames_to_ignore.push(usernameResult[1].toLowerCase());
+    } else {
+      let userIdResult = userIdRegex.exec(ignore.trim());
+      if (userIdResult) {
+        user_ids_to_ignore.push(parseInt(userIdResult[1]));
+      }
+    }
+  });
+}
+
 const bot = new TelegramBot(token, { polling: true });
 
 function log(msg) {
@@ -184,80 +204,93 @@ async function getLongUrl(shortURL) {
 
 bot.on("message", async (msg) => {
   try {
-    shortURLRegex.lastIndex = 0;
-    var replacements = [];
-    var match;
-    if (raw_links) {
-      rawUrlRegex.lastIndex = 0;
+    let from_username = msg.from.username.toLowerCase();
+    let from_id = msg.from.id;
+    if (
+      !usernames_to_ignore.includes(from_username) &&
+      !user_ids_to_ignore.includes(from_id)
+    ) {
+      shortURLRegex.lastIndex = 0;
+      var replacements = [];
+      var match;
+      if (raw_links) {
+        rawUrlRegex.lastIndex = 0;
 
-      while ((match = rawUrlRegex.exec(msg.text)) !== null) {
-        const fullURL = match[0];
+        while ((match = rawUrlRegex.exec(msg.text)) !== null) {
+          const fullURL = match[0];
 
-        replacements.push({ asin: null, fullURL: fullURL });
-      }
-    } else {
-      fullURLRegex.lastIndex = 0;
+          replacements.push({ asin: null, fullURL: fullURL });
+        }
+      } else {
+        fullURLRegex.lastIndex = 0;
 
-      while ((match = fullURLRegex.exec(msg.text)) !== null) {
-        const asin = match[8];
-        const fullURL = match[0];
-        replacements.push({ asin: asin, fullURL: fullURL });
-      }
-    }
-
-    while ((match = shortURLRegex.exec(msg.text)) !== null) {
-      const shortURL = match[0];
-      fullURLRegex.lastIndex = 0; // Otherwise sometimes getASINFromFullUrl won't succeed
-      const url = await getLongUrl(shortURL);
-
-      if (url != null) {
-        if (raw_links) {
-          replacements.push({
-            asin: null,
-            expanded_url: url.fullURL,
-            fullURL: shortURL,
-          });
-        } else {
-          replacements.push({
-            asin: getASINFromFullUrl(url.fullURL),
-            fullURL: shortURL,
-          });
+        while ((match = fullURLRegex.exec(msg.text)) !== null) {
+          const asin = match[8];
+          const fullURL = match[0];
+          replacements.push({ asin: asin, fullURL: fullURL });
         }
       }
-    }
 
-    if (replacements.length > 0) {
-      const text = await buildMessage(
-        msg.chat,
-        msg.text,
-        replacements,
-        msg.from
-      );
-      const deleted = deleteAndSend(msg.chat, msg.message_id, text);
+      while ((match = shortURLRegex.exec(msg.text)) !== null) {
+        const shortURL = match[0];
+        fullURLRegex.lastIndex = 0; // Otherwise sometimes getASINFromFullUrl won't succeed
+        const url = await getLongUrl(shortURL);
 
-      if (replacements.length > 1) {
-        replacements.forEach((element) => {
+        if (url != null) {
+          if (raw_links) {
+            replacements.push({
+              asin: null,
+              expanded_url: url.fullURL,
+              fullURL: shortURL,
+            });
+          } else {
+            replacements.push({
+              asin: getASINFromFullUrl(url.fullURL),
+              fullURL: shortURL,
+            });
+          }
+        }
+      }
+
+      if (replacements.length > 0) {
+        const text = await buildMessage(
+          msg.chat,
+          msg.text,
+          replacements,
+          msg.from
+        );
+        const deleted = deleteAndSend(msg.chat, msg.message_id, text);
+
+        if (replacements.length > 1) {
+          replacements.forEach((element) => {
+            log(
+              "Long URL " +
+                element.fullURL +
+                " -> ASIN " +
+                element.asin +
+                " from " +
+                buildMention(msg.from) +
+                (deleted ? " (original message deleted)" : "")
+            );
+          });
+        } else {
           log(
             "Long URL " +
-              element.fullURL +
+              replacements[0].fullURL +
               " -> ASIN " +
-              element.asin +
+              replacements[0].asin +
               " from " +
               buildMention(msg.from) +
               (deleted ? " (original message deleted)" : "")
           );
-        });
-      } else {
-        log(
-          "Long URL " +
-            replacements[0].fullURL +
-            " -> ASIN " +
-            replacements[0].asin +
-            " from " +
-            buildMention(msg.from) +
-            (deleted ? " (original message deleted)" : "")
-        );
+        }
       }
+    } else {
+      log(
+        `Ignored message from ${buildMention(
+          msg.from
+        )} because it is included in the IGNORE_USERS env variable`
+      );
     }
   } catch (e) {
     log(


### PR DESCRIPTION
Through the `IGNORE_USERS` environment variable it is possibile to create a comma-separated list of usernames (starting with the "@" character) and numeric user IDs whose messages won't be acted upon by the bot, even if they contain matching Amazon links.

A valid list would be "@YourUsername,12345678,@IgnoreMeAsWell123".

Numeric user IDs are useful for users who do not have Telegram user names defined. You can get yours by contacting [userinfobot](https://t.me/useridinfobot).