### PR TITLE
Ignored users are now ignored only in groups

### DIFF
--- a/index.js
+++ b/index.js
@@ -210,7 +210,7 @@ bot.on("message", async (msg) => {
     let from_id = msg.from.id;
     if (
       (!usernames_to_ignore.includes(from_username) &&
-      !user_ids_to_ignore.includes(from_id)) ||
+        !user_ids_to_ignore.includes(from_id)) ||
       !isGroup(msg.chat)
     ) {
       shortURLRegex.lastIndex = 0;

--- a/index.js
+++ b/index.js
@@ -209,8 +209,9 @@ bot.on("message", async (msg) => {
       : "";
     let from_id = msg.from.id;
     if (
-      !usernames_to_ignore.includes(from_username) &&
-      !user_ids_to_ignore.includes(from_id)
+      (!usernames_to_ignore.includes(from_username) &&
+      !user_ids_to_ignore.includes(from_id)) ||
+      !isGroup(msg.chat)
     ) {
       shortURLRegex.lastIndex = 0;
       var replacements = [];


### PR DESCRIPTION
As noted in #8, ignored users were ALWAYS ignored, even when messaging the bot directly. This PR solves that.