### PR TITLE
Fix amazon.com.br links not working

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,9 +8,13 @@ License: MIT
 const TelegramBot = require("node-telegram-bot-api");
 const fetch = require("node-fetch");
 
-const fullURLRegex = /https?:\/\/(([^\s]*)\.)?amazon\.([a-z.]{2,5})(\/d\/([^\s]*)|\/([^\s]*)\/?(?:dp|o|gp|-)\/)(aw\/d\/|product\/)?(B[0-9]{2}[0-9A-Z]{7}|[0-9]{9}(?:X|[0-9]))([^\s]*)/gi;
+const fullURLRegex = /https?:\/\/(([^\s]*)\.)?amazon\.([a-z.]{2,5}){1,2}(\/d\/([^\s]*)|\/([^\s]*)\/?(?:dp|o|gp|-)\/)(aw\/d\/|product\/)?(B[0-9]{2}[0-9A-Z]{7}|[0-9]{9}(?:X|[0-9]))([^\s]*)/gi;
 const shortURLRegex = /https?:\/\/(([^\s]*)\.)?amzn\.to\/([0-9A-Za-z]+)/gi;
 const URLRegex = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/gi;
+
+function regExpEscape(literal_string) {
+  return literal_string.replace(/[-[\]{}()*+!<=:?.\/\\^$|#\s,]/g, '\\$&');
+}
 
 if (!process.env.TELEGRAM_BOT_TOKEN) {
   console.log("Missing TELEGRAM_BOT_TOKEN env variable");
@@ -121,7 +125,7 @@ async function shortenURL(url) {
 }
 
 function buildAmazonUrl(asin) {
-  return `https://www.amazon.${amazon_tld}/dp/${asin}?tag=${amazon_tag}`;
+  return `https://www.amazon.${regExpEscape(amazon_tld)}/dp/${asin}?tag=${amazon_tag}`;
 }
 
 function buildRawAmazonUrl(element) {


### PR DESCRIPTION
Amazon Brazil's link is amazon.com.br, but setting `AMAZON_TLD=com.br` doesn't work because it contains a `.` that needs to be escaped on regex, and the `fullURLRegex`  didn't match the 3rd group (`.com.br`).

To fix it I:
- added a regex escape function to build the amazon URL
- changed the 3rd regex group for `fullURLRegex` to match from 1 to 2 times